### PR TITLE
CODEOWNERS: owning team Video - Media (251)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Video - Media (251).
+* @EENCloud/video-media-251


### PR DESCRIPTION
Ensures **EENMediaPlayer-Public** has a CODEOWNERS file naming its owning team **Video - Media (251)** (`@EENCloud/video-media-251`).

**Changes:** create .github/CODEOWNERS (@EENCloud/video-media-251)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
